### PR TITLE
Fix scrolling instability by adding padding for fixed header

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
     </div>
     <div id="critterCorner"></div>
 
-    <main id="scrollContainer" class="relative z-10 flex-1 overflow-y-auto overflow-x-hidden hide-scrollbar">
+    <main id="scrollContainer" class="relative z-10 flex-1 overflow-y-auto overflow-x-hidden hide-scrollbar pt-20">
         <section id="home" class="relative w-full max-w-5xl mx-auto py-16 md:py-24 px-6 min-h-screen flex items-center justify-center text-center">
             <div class="relative">
                 <div class="absolute -inset-2 bg-gradient-to-r from-green-600 to-cyan-600 rounded-lg blur-xl opacity-20"></div>


### PR DESCRIPTION
The website was unstable on scroll. This was caused by the fixed header overlapping the main content area. This change adds padding to the top of the main scroll container to offset the height of the fixed header, preventing the overlap and fixing the layout issue.