### PR TITLE
feat: add jump-on-click to seal and remove scrollbar

### DIFF
--- a/script.js
+++ b/script.js
@@ -580,10 +580,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 background: 'transparent'
             }
         });
-        render.canvas.style.position = 'absolute';
-        render.canvas.style.top = '0';
-        render.canvas.style.left = '0';
-        render.canvas.style.pointerEvents = 'none';
 
 
         const sealBody = Bodies.circle(150, 50, 50, {
@@ -617,6 +613,29 @@ document.addEventListener('DOMContentLoaded', () => {
 
         World.add(world, mouseConstraint);
         render.mouse = mouse;
+
+        let isDragging = false;
+        let startDragPos = { x: 0, y: 0 };
+
+        Matter.Events.on(mouseConstraint, 'mousedown', function(event) {
+            isDragging = false;
+            startDragPos = { x: event.mouse.position.x, y: event.mouse.position.y };
+        });
+
+        Matter.Events.on(mouseConstraint, 'mousemove', function(event) {
+            const dx = Math.abs(event.mouse.position.x - startDragPos.x);
+            const dy = Math.abs(event.mouse.position.y - startDragPos.y);
+            if (dx > 5 || dy > 5) {
+                isDragging = true;
+            }
+        });
+
+        Matter.Events.on(mouseConstraint, 'mouseup', function(event) {
+            if (!isDragging && mouseConstraint.body === sealBody) {
+                Matter.Body.applyForce(sealBody, sealBody.position, { x: 0, y: -0.1 * sealBody.mass });
+            }
+            isDragging = false;
+        });
 
         Render.run(render);
         const runner = Runner.create();

--- a/style.css
+++ b/style.css
@@ -56,6 +56,13 @@
     left: 0;
 }
 
+#critterCorner canvas {
+    position: absolute !important;
+    top: 0;
+    left: 0;
+    z-index: 100;
+}
+
 #seal {
     font-family: "Segoe UI Emoji", "Segoe UI Symbol", "Apple Color Emoji", "Twemoji Mozilla", "Noto Color Emoji", "Android Emoji";
 }
@@ -76,6 +83,7 @@ html {
 body {
     height: 100%;
     overflow-x: hidden;
+    overflow-y: hidden;
 }
 
 /* Ensure main content area takes available height and handles its own scrolling */


### PR DESCRIPTION
This commit enhances the draggable seal feature.

The seal now jumps when clicked, achieved by applying an upward force using Matter.js. A check is in place to distinguish between a click and a drag, so dragging does not trigger a jump.

The main body scrollbar has been removed by setting `overflow-y: hidden` in `style.css` to prevent scrolling issues while interacting with the seal.

The `z-index` of the Matter.js canvas has been raised to ensure it receives mouse events correctly.