### PR TITLE
fix(scrolling): Resolve scrolling conflict between body and scroll co…

### DIFF
--- a/style.css
+++ b/style.css
@@ -81,6 +81,7 @@ html {
 /* General body styling for full height and overflow */
 body {
     height: 100%;
+    overflow-y: hidden; /* Prevent body from scrolling, only scrollContainer */
     overflow-x: hidden;
 }
 


### PR DESCRIPTION
…ntainer

The primary scrolling mechanism for this single-page application is intended to be the `#scrollContainer` element. However, the `body` element also had a default scrollbar, which created a conflict and led to unpredictable scrolling behavior, especially when interacting with draggable elements.

This commit resolves the issue by adding `overflow-y: hidden` to the `body` element in `style.css`. This change explicitly prevents the body from scrolling, ensuring that the `#scrollContainer` is the sole scrolling context.

The existing JavaScript logic that temporarily disables scrolling on the container during drag operations has been preserved, as it is an intentional feature to improve the user experience. The fix has been verified with a Playwright script to confirm that both page scrolling and the drag-and-drop functionality work correctly without interference.